### PR TITLE
feat(ray): add cluster_selector support for long-lived Ray clusters

### DIFF
--- a/flyteidl/protos/flyteidl/plugins/ray.proto
+++ b/flyteidl/protos/flyteidl/plugins/ray.proto
@@ -8,7 +8,8 @@ import "flyteidl/core/tasks.proto";
 
 // RayJobSpec defines the desired state of RayJob
 message RayJob {
-  // RayClusterSpec is the cluster template to run the job
+  // RayClusterSpec is the cluster template to run the job.
+  // Mutually exclusive with cluster_selector - provide one or the other.
   RayCluster ray_cluster = 1;
   // runtime_env is base64 encoded.
   // Ray runtime environments: https://docs.ray.io/en/latest/ray-core/handling-dependencies.html#runtime-environments
@@ -20,6 +21,11 @@ message RayJob {
   // RuntimeEnvYAML represents the runtime environment configuration
   // provided as a multi-line YAML string.
   string runtime_env_yaml = 5;
+  // cluster_selector is a label selector to match an existing RayCluster.
+  // When set, the RayJob submits to an existing cluster instead of creating a new one.
+  // This enables long-lived clusters for faster iteration during development.
+  // Mutually exclusive with ray_cluster - provide one or the other.
+  map<string, string> cluster_selector = 6;
 }
 
 // Define Ray cluster defines the desired state of RayCluster

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray.go
@@ -125,8 +125,44 @@ func (rayJobResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsC
 }
 
 func constructRayJob(taskCtx pluginsCore.TaskExecutionContext, rayJob *plugins.RayJob, objectMeta *metav1.ObjectMeta, taskPodSpec v1.PodSpec, headNodeRayStartParams map[string]string, primaryContainerIdx int, primaryContainer v1.Container) (*rayv1.RayJob, error) {
-	enableIngress := true
 	cfg := GetConfig()
+
+	// Handle runtime_env conversion (needed for both modes)
+	var runtimeEnvYaml string
+	var err error
+	runtimeEnvYaml = rayJob.GetRuntimeEnvYaml()
+	// If runtime_env exists but runtime_env_yaml does not, convert runtime_env to runtime_env_yaml
+	if rayJob.GetRuntimeEnv() != "" && rayJob.GetRuntimeEnvYaml() == "" {
+		runtimeEnvYaml, err = convertBase64RuntimeEnvToYaml(rayJob.GetRuntimeEnv())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	submitterPodSpec := taskPodSpec.DeepCopy()
+	submitterPodTemplate := buildSubmitterPodTemplate(submitterPodSpec, objectMeta, taskCtx)
+
+	// Check if cluster_selector is provided - if so, use existing cluster mode
+	if len(rayJob.GetClusterSelector()) > 0 {
+		jobSpec := rayv1.RayJobSpec{
+			ClusterSelector:      rayJob.GetClusterSelector(),
+			Entrypoint:           strings.Join(primaryContainer.Args, " "),
+			RuntimeEnvYAML:       runtimeEnvYaml,
+			SubmitterPodTemplate: &submitterPodTemplate,
+		}
+
+		return &rayv1.RayJob{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       KindRayJob,
+				APIVersion: rayv1.SchemeGroupVersion.String(),
+			},
+			Spec:       jobSpec,
+			ObjectMeta: *objectMeta,
+		}, nil
+	}
+
+	// Default mode: create a new RayCluster
+	enableIngress := true
 
 	headPodSpec := taskPodSpec.DeepCopy()
 	headPodTemplate, err := buildHeadPodTemplate(
@@ -215,20 +251,6 @@ func constructRayJob(taskCtx pluginsCore.TaskExecutionContext, rayJob *plugins.R
 	if rayJob.GetShutdownAfterJobFinishes() {
 		shutdownAfterJobFinishes = true
 		ttlSecondsAfterFinished = &rayJob.TtlSecondsAfterFinished
-	}
-
-	submitterPodSpec := taskPodSpec.DeepCopy()
-	submitterPodTemplate := buildSubmitterPodTemplate(submitterPodSpec, objectMeta, taskCtx)
-
-	// TODO: This is for backward compatibility. Remove this block once runtime_env is removed from ray proto.
-	var runtimeEnvYaml string
-	runtimeEnvYaml = rayJob.GetRuntimeEnvYaml()
-	// If runtime_env exists but runtime_env_yaml does not, convert runtime_env to runtime_env_yaml
-	if rayJob.GetRuntimeEnv() != "" && rayJob.GetRuntimeEnvYaml() == "" {
-		runtimeEnvYaml, err = convertBase64RuntimeEnvToYaml(rayJob.GetRuntimeEnv())
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	jobSpec := rayv1.RayJobSpec{

--- a/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/ray/ray_test.go
@@ -1429,6 +1429,40 @@ func TestGetPropertiesRay(t *testing.T) {
 	assert.Equal(t, expected, rayJobResourceHandler.GetProperties())
 }
 
+func dummyRayCustomObjWithClusterSelector() *plugins.RayJob {
+	return &plugins.RayJob{
+		ClusterSelector: map[string]string{
+			"ray.io/cluster": "my-existing-cluster",
+		},
+		RuntimeEnvYaml: "pip:\n  - numpy",
+	}
+}
+
+func TestBuildResourceRayWithClusterSelector(t *testing.T) {
+	rayJobResourceHandler := rayJobResourceHandler{}
+	taskTemplate := dummyRayTaskTemplate("ray-id", dummyRayCustomObjWithClusterSelector())
+
+	err := config.SetK8sPluginConfig(&config.K8sPluginConfig{})
+	assert.Nil(t, err)
+
+	rayCtx := dummyRayTaskContext(taskTemplate, resourceRequirements, nil, "", serviceAccount)
+	RayResource, err := rayJobResourceHandler.BuildResource(context.TODO(), rayCtx)
+	assert.Nil(t, err)
+	assert.NotNil(t, RayResource)
+
+	ray, ok := RayResource.(*rayv1.RayJob)
+	assert.True(t, ok)
+
+	assert.NotNil(t, ray.Spec.ClusterSelector, "ClusterSelector should be set when cluster_selector is provided")
+	assert.Equal(t, map[string]string{"ray.io/cluster": "my-existing-cluster"}, ray.Spec.ClusterSelector)
+
+	assert.Nil(t, ray.Spec.RayClusterSpec, "RayClusterSpec should be nil when using cluster_selector")
+
+	assert.Equal(t, "pip:\n  - numpy", ray.Spec.RuntimeEnvYAML)
+
+	assert.NotNil(t, ray.Spec.SubmitterPodTemplate, "SubmitterPodTemplate should still be set")
+}
+
 func transformStructToStructPB(t *testing.T, obj interface{}) *structpb.Struct {
 	data, err := json.Marshal(obj)
 	assert.Nil(t, err)


### PR DESCRIPTION
# feat(ray): add cluster_selector support for long-lived Ray clusters

## Summary
Adds support for submitting RayJobs to existing RayCluster instances instead of creating new ephemeral clusters. This enables faster iteration during development by reusing long-lived clusters.

**Changes:**
- **flyteidl**: Added `cluster_selector` map field (field 6) to `RayJob` proto message, mutually exclusive with `ray_cluster`
- **flytepropeller**: Updated `constructRayJob()` to check for `cluster_selector` and set `ClusterSelector` on `RayJobSpec` instead of `RayClusterSpec` when provided

This leverages KubeRay's `clusterSelector` feature (requires KubeRay >= 1.1.0).

## Updates since last revision
- Added unit test `TestBuildResourceRayWithClusterSelector` to verify that when `cluster_selector` is provided, the RayJob uses `ClusterSelector` and does not set `RayClusterSpec`

## Review & Testing Checklist for Human

- [ ] **CRITICAL: Regenerate protobuf code** - The proto file was modified but `make generate` was not run. The `GetClusterSelector()` method called in ray.go and the new test won't compile until protobufs are regenerated.
- [ ] **Verify KubeRay dependency version** - Check that the KubeRay version in go.mod supports the `ClusterSelector` field on `RayJobSpec` (requires >= 1.1.0)
- [ ] **End-to-end test** - Create a long-lived RayCluster, then submit a RayJob with `cluster_selector` labels matching that cluster and verify it runs on the existing cluster (no new cluster created)

### Notes
- This is part of a multi-repo feature. Companion PR for flytekit-ray: https://github.com/exa-labs/flytekit/pull/17
- The cluster_selector mode intentionally omits `ShutdownAfterJobFinishes` and `TTLSecondsAfterFinished` since those don't apply when using an existing cluster
- Unit test added but will only compile after proto regeneration

---
Link to Devin run: https://app.devin.ai/sessions/91929162dbc241d8a83ef3c18aeb9aba
Requested by: @jld-adriano (adriano@exa.ai)