### PR TITLE
fix(propeller): bypass informer cache when clearing finalizers

### DIFF
--- a/flyteplugins/go/tasks/pluginmachinery/core/kube_client.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/kube_client.go
@@ -13,4 +13,9 @@ type KubeClient interface {
 
 	// GetCache returns a cache.Cache
 	GetCache() cache.Cache
+
+	// GetAPIReader returns a reader that bypasses the local informer cache and
+	// reads directly from the API server. Use this on paths where a stale cache
+	// could cause silent correctness bugs (e.g. clearing finalizers).
+	GetAPIReader() client.Reader
 }

--- a/flyteplugins/go/tasks/pluginmachinery/core/mocks/kube_client.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/mocks/kube_client.go
@@ -116,6 +116,53 @@ func (_c *KubeClient_GetClient_Call) RunAndReturn(run func() client.Client) *Kub
 	return _c
 }
 
+// GetAPIReader provides a mock function with given fields:
+func (_m *KubeClient) GetAPIReader() client.Reader {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAPIReader")
+	}
+
+	var r0 client.Reader
+	if rf, ok := ret.Get(0).(func() client.Reader); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(client.Reader)
+		}
+	}
+
+	return r0
+}
+
+// KubeClient_GetAPIReader_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAPIReader'
+type KubeClient_GetAPIReader_Call struct {
+	*mock.Call
+}
+
+// GetAPIReader is a helper method to define mock.On call
+func (_e *KubeClient_Expecter) GetAPIReader() *KubeClient_GetAPIReader_Call {
+	return &KubeClient_GetAPIReader_Call{Call: _e.mock.On("GetAPIReader")}
+}
+
+func (_c *KubeClient_GetAPIReader_Call) Run(run func()) *KubeClient_GetAPIReader_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *KubeClient_GetAPIReader_Call) Return(_a0 client.Reader) *KubeClient_GetAPIReader_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *KubeClient_GetAPIReader_Call) RunAndReturn(run func() client.Reader) *KubeClient_GetAPIReader_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewKubeClient creates a new instance of KubeClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewKubeClient(t interface {

--- a/flyteplugins/go/tasks/pluginmachinery/core/mocks/kube_client.go
+++ b/flyteplugins/go/tasks/pluginmachinery/core/mocks/kube_client.go
@@ -22,6 +22,53 @@ func (_m *KubeClient) EXPECT() *KubeClient_Expecter {
 	return &KubeClient_Expecter{mock: &_m.Mock}
 }
 
+// GetAPIReader provides a mock function with given fields:
+func (_m *KubeClient) GetAPIReader() client.Reader {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAPIReader")
+	}
+
+	var r0 client.Reader
+	if rf, ok := ret.Get(0).(func() client.Reader); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(client.Reader)
+		}
+	}
+
+	return r0
+}
+
+// KubeClient_GetAPIReader_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAPIReader'
+type KubeClient_GetAPIReader_Call struct {
+	*mock.Call
+}
+
+// GetAPIReader is a helper method to define mock.On call
+func (_e *KubeClient_Expecter) GetAPIReader() *KubeClient_GetAPIReader_Call {
+	return &KubeClient_GetAPIReader_Call{Call: _e.mock.On("GetAPIReader")}
+}
+
+func (_c *KubeClient_GetAPIReader_Call) Run(run func()) *KubeClient_GetAPIReader_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *KubeClient_GetAPIReader_Call) Return(_a0 client.Reader) *KubeClient_GetAPIReader_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *KubeClient_GetAPIReader_Call) RunAndReturn(run func() client.Reader) *KubeClient_GetAPIReader_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetCache provides a mock function with given fields:
 func (_m *KubeClient) GetCache() cache.Cache {
 	ret := _m.Called()
@@ -112,53 +159,6 @@ func (_c *KubeClient_GetClient_Call) Return(_a0 client.Client) *KubeClient_GetCl
 }
 
 func (_c *KubeClient_GetClient_Call) RunAndReturn(run func() client.Client) *KubeClient_GetClient_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetAPIReader provides a mock function with given fields:
-func (_m *KubeClient) GetAPIReader() client.Reader {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetAPIReader")
-	}
-
-	var r0 client.Reader
-	if rf, ok := ret.Get(0).(func() client.Reader); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(client.Reader)
-		}
-	}
-
-	return r0
-}
-
-// KubeClient_GetAPIReader_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAPIReader'
-type KubeClient_GetAPIReader_Call struct {
-	*mock.Call
-}
-
-// GetAPIReader is a helper method to define mock.On call
-func (_e *KubeClient_Expecter) GetAPIReader() *KubeClient_GetAPIReader_Call {
-	return &KubeClient_GetAPIReader_Call{Call: _e.mock.On("GetAPIReader")}
-}
-
-func (_c *KubeClient_GetAPIReader_Call) Run(run func()) *KubeClient_GetAPIReader_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *KubeClient_GetAPIReader_Call) Return(_a0 client.Reader) *KubeClient_GetAPIReader_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *KubeClient_GetAPIReader_Call) RunAndReturn(run func() client.Reader) *KubeClient_GetAPIReader_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/flyteplugins/go/tasks/pluginmachinery/k8s/client.go
+++ b/flyteplugins/go/tasks/pluginmachinery/k8s/client.go
@@ -13,8 +13,9 @@ import (
 )
 
 type kubeClient struct {
-	client client.Client
-	cache  cache.Cache
+	client    client.Client
+	cache     cache.Cache
+	apiReader client.Reader
 }
 
 func (k *kubeClient) GetClient() client.Client {
@@ -23,6 +24,16 @@ func (k *kubeClient) GetClient() client.Client {
 
 func (k *kubeClient) GetCache() cache.Cache {
 	return k.cache
+}
+
+// GetAPIReader returns a reader that bypasses the local cache. If a separate
+// cacheless reader was not configured, the read-write client is returned —
+// it already issues direct API calls.
+func (k *kubeClient) GetAPIReader() client.Reader {
+	if k.apiReader != nil {
+		return k.apiReader
+	}
+	return k.client
 }
 
 func newKubeClient(c client.Client, cache cache.Cache) core.KubeClient {

--- a/flyteplugins/go/tasks/plugins/array/k8s/executor.go
+++ b/flyteplugins/go/tasks/plugins/array/k8s/executor.go
@@ -37,6 +37,13 @@ func (k KubeClientObj) GetCache() cache.Cache {
 	return nil
 }
 
+// GetAPIReader returns the underlying client. KubeClientObj does not maintain
+// a separate informer cache, so reads through GetClient already hit the API
+// server directly.
+func (k KubeClientObj) GetAPIReader() client.Reader {
+	return k.client
+}
+
 func NewKubeClientObj(c client.Client) core.KubeClient {
 	return &KubeClientObj{
 		client: c,

--- a/flytepropeller/pkg/controller/executors/kube.go
+++ b/flytepropeller/pkg/controller/executors/kube.go
@@ -22,6 +22,13 @@ type Client interface {
 
 	// GetCache returns a cache.Cache
 	GetCache() cache.Cache
+
+	// GetAPIReader returns a reader that bypasses the local informer cache and
+	// reads directly from the API server. Use this on paths where a stale cache
+	// could cause silent correctness bugs (for example, when checking whether a
+	// finalizer is still attached to an object that was just modified by an
+	// external controller).
+	GetAPIReader() client.Reader
 }
 
 var NewCache = func(config *rest.Config, options cache.Options) (cache.Cache, error) {

--- a/flytepropeller/pkg/controller/executors/mocks/client.go
+++ b/flytepropeller/pkg/controller/executors/mocks/client.go
@@ -22,6 +22,53 @@ func (_m *Client) EXPECT() *Client_Expecter {
 	return &Client_Expecter{mock: &_m.Mock}
 }
 
+// GetAPIReader provides a mock function with given fields:
+func (_m *Client) GetAPIReader() client.Reader {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAPIReader")
+	}
+
+	var r0 client.Reader
+	if rf, ok := ret.Get(0).(func() client.Reader); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(client.Reader)
+		}
+	}
+
+	return r0
+}
+
+// Client_GetAPIReader_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAPIReader'
+type Client_GetAPIReader_Call struct {
+	*mock.Call
+}
+
+// GetAPIReader is a helper method to define mock.On call
+func (_e *Client_Expecter) GetAPIReader() *Client_GetAPIReader_Call {
+	return &Client_GetAPIReader_Call{Call: _e.mock.On("GetAPIReader")}
+}
+
+func (_c *Client_GetAPIReader_Call) Run(run func()) *Client_GetAPIReader_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Client_GetAPIReader_Call) Return(_a0 client.Reader) *Client_GetAPIReader_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Client_GetAPIReader_Call) RunAndReturn(run func() client.Reader) *Client_GetAPIReader_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetCache provides a mock function with given fields:
 func (_m *Client) GetCache() cache.Cache {
 	ret := _m.Called()
@@ -112,53 +159,6 @@ func (_c *Client_GetClient_Call) Return(_a0 client.Client) *Client_GetClient_Cal
 }
 
 func (_c *Client_GetClient_Call) RunAndReturn(run func() client.Client) *Client_GetClient_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetAPIReader provides a mock function with given fields:
-func (_m *Client) GetAPIReader() client.Reader {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetAPIReader")
-	}
-
-	var r0 client.Reader
-	if rf, ok := ret.Get(0).(func() client.Reader); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(client.Reader)
-		}
-	}
-
-	return r0
-}
-
-// Client_GetAPIReader_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAPIReader'
-type Client_GetAPIReader_Call struct {
-	*mock.Call
-}
-
-// GetAPIReader is a helper method to define mock.On call
-func (_e *Client_Expecter) GetAPIReader() *Client_GetAPIReader_Call {
-	return &Client_GetAPIReader_Call{Call: _e.mock.On("GetAPIReader")}
-}
-
-func (_c *Client_GetAPIReader_Call) Run(run func()) *Client_GetAPIReader_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *Client_GetAPIReader_Call) Return(_a0 client.Reader) *Client_GetAPIReader_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *Client_GetAPIReader_Call) RunAndReturn(run func() client.Reader) *Client_GetAPIReader_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/flytepropeller/pkg/controller/executors/mocks/client.go
+++ b/flytepropeller/pkg/controller/executors/mocks/client.go
@@ -116,6 +116,53 @@ func (_c *Client_GetClient_Call) RunAndReturn(run func() client.Client) *Client_
 	return _c
 }
 
+// GetAPIReader provides a mock function with given fields:
+func (_m *Client) GetAPIReader() client.Reader {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAPIReader")
+	}
+
+	var r0 client.Reader
+	if rf, ok := ret.Get(0).(func() client.Reader); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(client.Reader)
+		}
+	}
+
+	return r0
+}
+
+// Client_GetAPIReader_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAPIReader'
+type Client_GetAPIReader_Call struct {
+	*mock.Call
+}
+
+// GetAPIReader is a helper method to define mock.On call
+func (_e *Client_Expecter) GetAPIReader() *Client_GetAPIReader_Call {
+	return &Client_GetAPIReader_Call{Call: _e.mock.On("GetAPIReader")}
+}
+
+func (_c *Client_GetAPIReader_Call) Run(run func()) *Client_GetAPIReader_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Client_GetAPIReader_Call) Return(_a0 client.Reader) *Client_GetAPIReader_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Client_GetAPIReader_Call) RunAndReturn(run func() client.Reader) *Client_GetAPIReader_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewClient creates a new instance of Client. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewClient(t interface {

--- a/flytepropeller/pkg/controller/executors/mocks/fake.go
+++ b/flytepropeller/pkg/controller/executors/mocks/fake.go
@@ -45,7 +45,9 @@ func (f *FakeInformers) GetInformer(ctx context.Context, obj client.Object, opts
 
 func NewFakeKubeClient() *Client {
 	c := Client{}
-	c.EXPECT().GetClient().Return(fake.NewClientBuilder().WithRuntimeObjects().Build())
+	fakeClient := fake.NewClientBuilder().WithRuntimeObjects().Build()
+	c.EXPECT().GetClient().Return(fakeClient)
 	c.EXPECT().GetCache().Return(&FakeInformers{})
+	c.EXPECT().GetAPIReader().Return(fakeClient)
 	return &c
 }

--- a/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -504,10 +504,16 @@ func (e *PluginManager) Finalize(ctx context.Context, tCtx pluginsCore.TaskExecu
 	// Attempt to cleanup finalizer so that the object may be deleted/garbage collected. We try to clear it for all
 	// objects, regardless of whether or not InjectFinalizer is configured to handle all cases where InjectFinalizer is
 	// enabled/disabled during object execution.
+	//
+	// The Get below intentionally uses GetAPIReader to bypass the informer cache. The cache can lag the API server
+	// (and lags much longer when the watch verb is missing in RBAC and the reflector falls back to LIST resyncs).
+	// A stale cached read can show a copy whose Finalizers list does not contain ours even though the API server
+	// still has it; clearFinalizer below would then see RemoveFinalizer == false and silently skip the patch,
+	// leaving the resource permanently stuck Terminating.
 	var lastErr error
 	_ = wait.ExponentialBackoff(retryBackoff, func() (bool, error) {
 		lastErr = nil
-		if err := e.kubeClient.GetClient().Get(ctx, nsName, o); err != nil {
+		if err := e.kubeClient.GetAPIReader().Get(ctx, nsName, o); err != nil {
 			if isK8sObjectNotExists(err) {
 				return true, nil
 			}


### PR DESCRIPTION
## Tracking issue

Internal — see Slack thread.

## Why are the changes needed?

`PluginManager.Finalize` reads the resource through the informer cache and then calls `clearFinalizer`, which uses `controllerutil.RemoveFinalizer` on that copy and only sends the merge-patch when `RemoveFinalizer` returns `true`. When the cache is stale relative to the API server, the cached copy can lack a finalizer that the API server still has — `RemoveFinalizer` returns `false`, the patch is never sent, and the function returns nil. The caller treats finalize as successful, the node phase advances, and the resource is left forever with `deletionTimestamp` set and our finalizer attached.

```go
// flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager.go (before)
if err := e.kubeClient.GetClient().Get(ctx, nsName, o); err != nil { ... }
if err := e.clearFinalizer(ctx, o); err != nil { ... }
```

```go
// clearFinalizer (unchanged)
finalizerRemoved := controllerutil.RemoveFinalizer(o, finalizer)
oldFinalizerRemoved := controllerutil.RemoveFinalizer(o, oldFinalizer)
if finalizerRemoved || oldFinalizerRemoved {
    e.kubeClient.GetClient().Patch(ctx, o, client.MergeFrom(orig))
} else {
    logger.Debugf(ctx, "Finalizer is already cleared from Resource ...")
    // returns nil — silent no-op
}
```

The `flyteK8sClient.Get` wrapper is cache-first (it calls `cacheReader.Get` and only falls through to the API server on cache error), so any informer staleness propagates straight into this codepath. Staleness windows widen significantly when the watch verb is missing in RBAC and the reflector falls back to repeated LISTs (visible in propeller logs as `reflector.go:147] Failed to watch *v1.RayJob: unknown (get rayjobs.ray.io)`).

This is the propeller-side half of a fix for hephaestus, where 258 of 263 RayJobs in `flytesnacks-*` ended up stuck `Terminating` with `flyte.org/finalizer-k8s` attached, pinning RayCluster head/worker pods and blocking node consolidation. The companion change adds the missing `watch` / `deletecollection` RBAC verbs.

## What changes were proposed in this pull request?

Add a `GetAPIReader() client.Reader` method to both kube-client interfaces (`executors.Client` in flytepropeller and `core.KubeClient` in flyteplugins) and use it for the `Get` inside `Finalize`. The new reader bypasses the informer cache and reads directly from the API server, so the object passed to `clearFinalizer` always reflects the API server's current `Finalizers` list. If the finalizer is still present, `RemoveFinalizer` returns true and the merge-patch goes out; if it really was already removed, the no-op log is correct.

Implementations updated:
- `executors.flyteK8sClient` — relies on the embedded cacheless `client.Client` it was already constructed with.
- `pluginmachinery/k8s.kubeClient` — adds an optional `apiReader`; falls back to the existing `client` (which already issues direct API calls) when no separate cacheless reader was wired in.
- `pluginmachinery/array/k8s.KubeClientObj` — returns the underlying client (already cacheless).
- Mocks under `executors/mocks/` and `pluginmachinery/core/mocks/` — generated-style additions for `GetAPIReader`. `NewFakeKubeClient()` returns the same `fake.Client` for both `GetClient` and `GetAPIReader`.

Writes are unchanged — `Patch` already goes to the API server via the embedded cacheless client.

## How was this patch tested?

- `go build ./...` and `go vet ./...` clean for both `flytepropeller` and `flyteplugins`.
- `go test ./...` passes for both modules. `TestFinalize` in `flytepropeller/pkg/controller/nodes/task/k8s/plugin_manager_test.go` continues to pass after `NewFakeKubeClient()` was updated to also stub `GetAPIReader`.

End-to-end verification will happen on hephaestus after the companion RBAC PR (exa-labs/monorepo#34236) lands and this image is rolled out: new RayJob completions should no longer accumulate `flyte.org/finalizer-k8s` on terminating objects.

### Labels

fixed

### Setup process

n/a — server-side fix, no migrations / config changes required.

### Screenshots

n/a

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

- exa-labs/monorepo#34236 — RBAC: add `watch` + `deletecollection` for rayjobs / pytorchjobs.

## Docs link

n/a


Link to Devin session: https://app.devin.ai/sessions/4884d86b33694c858a1abdf476f20ed8
Requested by: @pfernandes21