### PR TITLE
[security]: add TruffleHog secret scanning

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,0 +1,21 @@
+name: Secret Scanning
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  trufflehog:
+    name: TruffleHog Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: TruffleHog
+        uses: trufflesecurity/trufflehog@v3.88.0
+        with:
+          extra_args: --only-verified


### PR DESCRIPTION
## Tracking issue
SEC-38

## Why are the changes needed?

A historical Terraform file contained a hardcoded database password. That Terraform path has already been deleted from `master`, and the reported RDS cluster does not exist in us-west-2, but the repo did not have CI coverage to catch future committed secrets.

## What changes were proposed in this pull request?

Adds a GitHub Actions workflow that runs TruffleHog on pull requests and `master` pushes. The scan uses `--only-verified` so CI fails on live, verified credentials while avoiding noise from historical/test strings.

## How was this patch tested?

- `git diff --check origin/master...HEAD`
- Confirmed the reported file no longer exists on `master`
- Confirmed `flyteadmin-cluster` does not exist in AWS RDS us-west-2
- CI: `TruffleHog Secret Scan` passed

### Labels

security

### Setup process

N/A

### Screenshots

N/A

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

N/A

## Docs link

N/A

Link to Devin session: https://app.devin.ai/sessions/45c81ad103e3473498643cb74c3a8347
Requested by: @pschork