### PR TITLE
kfpytorch: add configurable default CleanPodPolicy and TTLSecondsAfterFinished

### DIFF
--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/config.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/config.go
@@ -11,16 +11,28 @@ import (
 
 var (
 	defaultConfig = Config{
-		Timeout: config.Duration{Duration: 1 * time.Minute},
+		Timeout:                        config.Duration{Duration: 1 * time.Minute},
+		DefaultTTLSecondsAfterFinished: -1,
 	}
 
 	configSection = pluginsConfig.MustRegisterSubSection("kf-operator", &defaultConfig)
 )
 
-// Config is config for 'pytorch' plugin
+// Config is config for kubeflow operator plugins (pytorch, tensorflow).
 type Config struct {
 	// If kubeflow operator doesn't update the status of the task after this timeout, the task will be considered failed.
 	Timeout config.Duration `json:"timeout,omitempty"`
+
+	// DefaultCleanPodPolicy sets the default CleanPodPolicy on training jobs when
+	// the task spec does not provide one. Valid values: "None", "Running", "All".
+	// When empty, no default is applied and the training operator's own default is used.
+	DefaultCleanPodPolicy string `json:"defaultCleanPodPolicy,omitempty"`
+
+	// DefaultTTLSecondsAfterFinished sets a default TTL on finished training jobs
+	// when the task spec does not provide one. The training operator will garbage-
+	// collect the job and its pods after this many seconds. 0 means immediate cleanup.
+	// -1 (default) means no default is applied.
+	DefaultTTLSecondsAfterFinished int32 `json:"defaultTTLSecondsAfterFinished,omitempty"`
 }
 
 func GetConfig() *Config {

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/config_flags.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/config_flags.go
@@ -51,5 +51,7 @@ func (Config) mustMarshalJSON(v json.Marshaler) string {
 func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("Config", pflag.ExitOnError)
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "timeout"), defaultConfig.Timeout.String(), "")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "defaultCleanPodPolicy"), defaultConfig.DefaultCleanPodPolicy, "")
+	cmdFlags.Int32(fmt.Sprintf("%v%v", prefix, "defaultTTLSecondsAfterFinished"), defaultConfig.DefaultTTLSecondsAfterFinished, "")
 	return cmdFlags
 }

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/config_flags_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/common/config_flags_test.go
@@ -113,4 +113,32 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_defaultCleanPodPolicy", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "All"
+
+			cmdFlags.Set("defaultCleanPodPolicy", testValue)
+			if vString, err := cmdFlags.GetString("defaultCleanPodPolicy"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.DefaultCleanPodPolicy)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
+	t.Run("Test_defaultTTLSecondsAfterFinished", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "3600"
+
+			cmdFlags.Set("defaultTTLSecondsAfterFinished", testValue)
+			if vInt32, err := cmdFlags.GetInt32("defaultTTLSecondsAfterFinished"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vInt32), &actual.DefaultTTLSecondsAfterFinished)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 }

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
@@ -144,6 +144,17 @@ func (p pytorchOperatorResourceHandler) BuildResource(ctx context.Context, taskC
 			"Invalid TaskSpecification, unsupported task template version [%v] key", taskTemplate.GetTaskTypeVersion())
 	}
 
+	// Apply config-level defaults for RunPolicy fields the task didn't set.
+	cfg := common.GetConfig()
+	if runPolicy.CleanPodPolicy == nil && cfg.DefaultCleanPodPolicy != "" {
+		policy := kubeflowv1.CleanPodPolicy(cfg.DefaultCleanPodPolicy)
+		runPolicy.CleanPodPolicy = &policy
+	}
+	if runPolicy.TTLSecondsAfterFinished == nil && cfg.DefaultTTLSecondsAfterFinished >= 0 {
+		ttl := cfg.DefaultTTLSecondsAfterFinished
+		runPolicy.TTLSecondsAfterFinished = &ttl
+	}
+
 	jobSpec := kubeflowv1.PyTorchJobSpec{}
 	replicaSpecs := map[kubeflowv1.ReplicaType]*kubeflowv1.ReplicaSpec{
 		kubeflowv1.PyTorchJobReplicaTypeMaster: masterReplicaSpec,

--- a/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
+++ b/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
@@ -993,6 +993,81 @@ func TestBuildResourcePytorchV1WithRunPolicy(t *testing.T) {
 	}
 }
 
+func TestBuildResourcePytorchV1WithConfigDefaults(t *testing.T) {
+	// When the task spec does not set a RunPolicy the config-level defaults should
+	// be applied so that the training operator cleans up pods on its own.
+	err := common.SetConfig(&common.Config{
+		DefaultCleanPodPolicy:          "All",
+		DefaultTTLSecondsAfterFinished: 3600,
+	})
+	assert.NoError(t, err)
+	defer func() {
+		// Restore default config for other tests.
+		_ = common.SetConfig(&common.Config{
+			DefaultTTLSecondsAfterFinished: -1,
+		})
+	}()
+
+	taskConfig := &kfplugins.DistributedPyTorchTrainingTask{
+		WorkerReplicas: &kfplugins.DistributedPyTorchTrainingReplicaSpec{
+			Replicas: 2,
+		},
+		// No RunPolicy — config defaults should kick in.
+	}
+
+	pytorchResourceHandler := pytorchOperatorResourceHandler{}
+	taskTemplate := dummyPytorchTaskTemplate("config-defaults", taskConfig)
+	taskTemplate.TaskTypeVersion = 1
+
+	res, err := pytorchResourceHandler.BuildResource(context.TODO(), dummyPytorchTaskContext(taskTemplate, resourceRequirements, nil, "", k8s.PluginState{}))
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+
+	pytorchJob, ok := res.(*kubeflowv1.PyTorchJob)
+	assert.True(t, ok)
+	assert.Equal(t, kubeflowv1.CleanPodPolicyAll, *pytorchJob.Spec.RunPolicy.CleanPodPolicy)
+	assert.Equal(t, int32(3600), *pytorchJob.Spec.RunPolicy.TTLSecondsAfterFinished)
+}
+
+func TestBuildResourcePytorchV1WithConfigDefaultsNoOverrideExplicitPolicy(t *testing.T) {
+	// When the task spec explicitly sets a RunPolicy the config defaults must NOT
+	// override the task-level values.
+	err := common.SetConfig(&common.Config{
+		DefaultCleanPodPolicy:          "Running",
+		DefaultTTLSecondsAfterFinished: 7200,
+	})
+	assert.NoError(t, err)
+	defer func() {
+		_ = common.SetConfig(&common.Config{
+			DefaultTTLSecondsAfterFinished: -1,
+		})
+	}()
+
+	taskConfig := &kfplugins.DistributedPyTorchTrainingTask{
+		WorkerReplicas: &kfplugins.DistributedPyTorchTrainingReplicaSpec{
+			Replicas: 2,
+		},
+		RunPolicy: &kfplugins.RunPolicy{
+			CleanPodPolicy:          kfplugins.CleanPodPolicy_CLEANPOD_POLICY_ALL,
+			TtlSecondsAfterFinished: 10000,
+		},
+	}
+
+	pytorchResourceHandler := pytorchOperatorResourceHandler{}
+	taskTemplate := dummyPytorchTaskTemplate("config-no-override", taskConfig)
+	taskTemplate.TaskTypeVersion = 1
+
+	res, err := pytorchResourceHandler.BuildResource(context.TODO(), dummyPytorchTaskContext(taskTemplate, resourceRequirements, nil, "", k8s.PluginState{}))
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+
+	pytorchJob, ok := res.(*kubeflowv1.PyTorchJob)
+	assert.True(t, ok)
+	// Task-level values should win over config defaults.
+	assert.Equal(t, kubeflowv1.CleanPodPolicyAll, *pytorchJob.Spec.RunPolicy.CleanPodPolicy)
+	assert.Equal(t, int32(10000), *pytorchJob.Spec.RunPolicy.TTLSecondsAfterFinished)
+}
+
 func TestBuildResourcePytorchV1WithOnlyWorkerSpec(t *testing.T) {
 	taskConfigs := []*kfplugins.DistributedPyTorchTrainingTask{
 		{


### PR DESCRIPTION
## Summary

Adds two new `kf-operator` plugin config fields so that propeller can set default `CleanPodPolicy` and `TTLSecondsAfterFinished` on PyTorchJobs when the task spec doesn't provide a `RunPolicy`.

**Problem:** When a PyTorchJob (especially elastic) fails and propeller can't remove its `flyte.org/finalizer` (crash, restart, race condition), the worker pods survive indefinitely as zombies — blocking GPUs. This happened today with 15 H200-hogging pods from a failed Devin run.

**Root cause:** The kfpytorch plugin creates `RunPolicy{}` with nil `CleanPodPolicy` and nil `TTLSecondsAfterFinished`. For elastic PyTorchJobs, the training operator defaults `CleanPodPolicy` to `None`, meaning it never cleans up pods on its own. There's no TTL safety net either. Cleanup depends entirely on propeller's finalizer — a single point of failure.

**Fix:** Two new config-level defaults applied when the task spec doesn't set them:
- `defaultCleanPodPolicy` — e.g. `"All"` to have the training operator delete all pods when the job terminates
- `defaultTTLSecondsAfterFinished` — e.g. `3600` so the training operator GCs the job + pods after 1h even if `CleanPodPolicy` didn't fire

This mirrors the Ray plugin's existing `ttlSecondsAfterFinished: 3600` and `shutdownAfterJobFinishes: true` pattern.

Task-level `RunPolicy` values always take precedence over config defaults.

**To activate** (separate monorepo PR after this merges):
```yaml
plugins:
  kf-operator:
    defaultCleanPodPolicy: All
    defaultTTLSecondsAfterFinished: 3600
```

**Files changed:**
- `common/config.go` — new config fields + default (`-1` = disabled)
- `common/config_flags.go` / `config_flags_test.go` — regenerated pflags
- `pytorch/pytorch.go` — apply config defaults to `runPolicy` before building the job spec
- `pytorch/pytorch_test.go` — two new tests: defaults applied when no RunPolicy, and task-level values not overridden

## Review & Testing Checklist for Human
- [ ] Verify the config defaults only apply when the task spec doesn't set a RunPolicy (the `NoOverrideExplicitPolicy` test covers this, but worth a manual check)
- [ ] After merging, add the `kf-operator` config to monorepo helm values (`ansible/hephaestus/stacks/flyte/helm/values.yaml`) and deploy
- [ ] Run a test elastic PyTorchJob, kill propeller mid-execution, and confirm worker pods are cleaned up by the training operator after the TTL

### Notes
- The `-1` sentinel for `defaultTTLSecondsAfterFinished` means "don't apply any default" — this keeps the behavior unchanged until the helm config is updated
- Pod logs are still available in Loki after cleanup, so there's no debugging impact from enabling this
- All existing kf-operator tests pass (pytorch, tensorflow, mpi, common)

Link to Devin session: https://app.devin.ai/sessions/a4214af2424548e4ac0f9d5c3a3901c7
Requested by: @pfernandes21