### PR TITLE
fix(ci): correct stale Helm repository URLs in Release Charts workflow

### DIFF
--- a/.github/workflows/github-helm-charts.yaml
+++ b/.github/workflows/github-helm-charts.yaml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Add required Helm repositories
         run: |
-          helm repo add twun https://helm.twun.io/
-          helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
+          helm repo add twun https://twuni.github.io/docker-registry.helm
+          helm repo add kubernetes-dashboard https://kubernetes-retired.github.io/dashboard/
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo update
 


### PR DESCRIPTION
## Tracking issue

Related to #16

## Why are the changes needed?

The `Release Charts` workflow — the chart-releaser job that publishes to gh-pages, i.e. the only thing that puts charts on `https://exa-labs.github.io/flyte` — has been failing on every push to master since at least the #14 merge in June. It dies in the "Add required Helm repositories" step, before chart-releaser ever runs, so gh-pages has been frozen at `flyte-binary v0.1.10`.

Two of the three repository URLs it adds no longer exist:

```text
https://helm.twun.io/                      -> DNS NXDOMAIN
https://kubernetes.github.io/dashboard/    -> 404
```

Neither is what the charts actually declare. `charts/flyte-sandbox/Chart.yaml` (and `validate-helm-charts.yaml`, which is why chart validation still passes) point at the live URLs. This went unnoticed because nothing needed a newly published chart until now — `flyte-binary v0.1.11` was merged in #16 and never made it to the index.

## What changes were proposed in this pull request?

Point the two stale URLs at the ones the charts declare:

```diff
- helm repo add twun https://helm.twun.io/
- helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
+ helm repo add twun https://twuni.github.io/docker-registry.helm
+ helm repo add kubernetes-dashboard https://kubernetes-retired.github.io/dashboard/
```

Bitnami is left alone — see testing below.

Out of scope: the separate `Package & Push Flyte Helm Charts` workflow also fails, with `Username and password required`, because `FLYTE_BOT_USERNAME`/`FLYTE_BOT_PAT` aren't set on this fork. That's an upstream GHCR dev-chart path we don't consume, and it's a secrets gap rather than something a diff can fix.

## How was this patch tested?

Ran the corrected step's exact command sequence locally, then resolved dependencies for both charts:

```console
$ helm repo add twun https://twuni.github.io/docker-registry.helm
$ helm repo add kubernetes-dashboard https://kubernetes-retired.github.io/dashboard/
$ helm repo add bitnami https://charts.bitnami.com/bitnami
$ helm repo update
$ helm dep update charts/flyte-sandbox
docker-registry       2.2.2     ok
flyte-binary          v0.1.11   ok
kubernetes-dashboard  6.0.0     ok
minio                 12.6.7    ok
postgresql            12.8.1    ok
$ helm dep update charts/flyte-binary
flyteconnector        v0.1.10   ok
```

`helm lint` passes on both charts.

Bitnami was checked explicitly rather than assumed, since Bitnami has been retiring its legacy chart index: `https://charts.bitnami.com/bitnami` 302-redirects to `repo.broadcom.com` but still serves a valid `index.yaml`, and both pinned versions (`minio 12.6.7`, `postgresql 12.8.1`) download as valid archives. It works today, but it is a redirect away from breaking this workflow the same way.

The real verification is the next push to master: `v0.1.11` should appear in `https://exa-labs.github.io/flyte/index.yaml`.

### Labels

**fixed**

## Check all the applicable boxes

- [x] I updated the documentation accordingly. (n/a — CI-only change)
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

- #16 — the HA change whose `flyte-binary v0.1.11` is stuck unpublished because of this.


Link to Devin session: https://app.devin.ai/sessions/137e980b425d43668660198d80b6e21d
Requested by: @Vervious