### PR TITLE
fix(ci): regenerate the Helm index unconditionally so published charts are discoverable

### DIFF
--- a/.github/workflows/github-helm-charts.yaml
+++ b/.github/workflows/github-helm-charts.yaml
@@ -39,3 +39,37 @@ jobs:
           skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Regenerate Helm repository index
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          set -euo pipefail
+
+          rm -rf .cr-index .cr-release-packages
+          mkdir -p .cr-release-packages
+
+          while IFS=$'\t' read -r tag asset; do
+            gh release download "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "$asset" \
+              --dir .cr-release-packages \
+              --clobber
+          done < <(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+              --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name as $tag | .assets[] | select(.name | endswith(".tgz")) | [$tag, .name] | @tsv'
+          )
+
+          repo="${GITHUB_REPOSITORY#*/}"
+          cr index \
+            --owner "$GITHUB_REPOSITORY_OWNER" \
+            --git-repo "$repo" \
+            --token "$CR_TOKEN" \
+            --package-path .cr-release-packages \
+            --index-path .cr-index/index.yaml \
+            --remote origin \
+            --pages-branch gh-pages \
+            --pages-index-path index.yaml \
+            --push

--- a/.github/workflows/github-helm-charts.yaml
+++ b/.github/workflows/github-helm-charts.yaml
@@ -40,12 +40,41 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Install chart-releaser
+        env:
+          CHART_RELEASER_VERSION: v1.6.1
+        run: |
+          set -euo pipefail
+
+          case "$(uname -m)" in
+            x86_64) arch=amd64 ;;
+            aarch64) arch=arm64 ;;
+            *)
+              echo "Unsupported runner architecture: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+
+          install_dir="$RUNNER_TEMP/chart-releaser/$CHART_RELEASER_VERSION"
+          archive="$RUNNER_TEMP/chart-releaser.tar.gz"
+          mkdir -p "$install_dir"
+          curl -fsSL \
+            -o "$archive" \
+            "https://github.com/helm/chart-releaser/releases/download/$CHART_RELEASER_VERSION/chart-releaser_${CHART_RELEASER_VERSION#v}_linux_${arch}.tar.gz"
+          tar -xzf "$archive" -C "$install_dir"
+          echo "$install_dir" >> "$GITHUB_PATH"
+          "$install_dir/cr" version
+
       - name: Regenerate Helm repository index
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           set -euo pipefail
+
+          if ! git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
+            git fetch origin gh-pages:refs/remotes/origin/gh-pages
+          fi
 
           rm -rf .cr-index .cr-release-packages
           mkdir -p .cr-release-packages


### PR DESCRIPTION
## Tracking issue

Related to #17, #18

## Why are the changes needed?

`flyte-binary` v0.1.11 exists as a GitHub Release with a valid `.tgz` asset, but it is not in the published Helm index, so `helm repo add https://exa-labs.github.io/flyte` still only offers v0.1.10 and any consumer pinning v0.1.11 fails with `chart "flyte-binary" version "v0.1.11" not found`.

`Release Charts` is green, so nothing surfaces this. The cause is chart-releaser's own control flow: it only runs `cr index` inside the "changed charts" branch. The run that created the v0.1.11 release failed later (during upload of unchanged charts), before indexing. Every run after that discovers no changed charts *since* `flyte-binary-v0.1.11` and exits early:

```text
Discovering changed charts since 'flyte-binary-v0.1.11'...
Nothing to do. No chart changes detected.
```

So the index is permanently stuck: releasing the chart and publishing the index are coupled to the same change detection, and the release half already happened. gh-pages has not been updated since 2025-04-23.

## What changes were proposed in this pull request?

Decouple index generation from chart-releaser's change detection by regenerating the index unconditionally after the action runs.

- **Install `chart-releaser`** pinned to `v1.6.1` (the version `chart-releaser-action@v1.6.0` resolves to) and add it to `$GITHUB_PATH`. The action's `cr.sh` only does `export PATH=...` in its own process, so `cr` is not otherwise available to later steps. Installing explicitly avoids reaching into `$RUNNER_TOOL_CACHE/cr/<version>/<arch>`, which would silently break whenever the action bumps its default.
- **Regenerate and push the index**: enumerate every non-draft, non-prerelease `.tgz` release asset, download them into `.cr-release-packages` (`cr index` needs the local packages to read chart metadata and compute digests; it does not reconstruct them from the API), then `cr index --push --pages-branch gh-pages`.

Deliberately not done: bumping the chart to v0.1.12 to make change detection fire again, deleting the existing v0.1.11 release/tag, or hand-editing gh-pages. The published v0.1.11 asset is the artifact consumers will pull; it should stay exactly as released.

Two properties worth noting:
- The step is a no-op when the index is already current — `cr`'s `UpdateIndexFile` logs `Index ... did not change` and returns before commit/push, so master pushes don't accumulate empty gh-pages commits.
- `cr index` does `git worktree add --detach <path> origin/gh-pages` and fails if that ref is missing locally, so the step fetches it when absent rather than relying on `fetch-depth: 0` behaviour.

## How was this patch tested?

CI cannot test this: `Release Charts` only runs on push to master. Verified locally instead, against the real repository state:

1. Installed the pinned `cr` `v1.6.1` and confirmed `cr version`.
2. Ran the same release-enumeration and download logic against `exa-labs/flyte` — 7 chart packages downloaded, including `flyte-binary-v0.1.11.tgz`.
3. Ran `cr index` (without `--push`) against the current `origin/gh-pages` worktree. It found `flyte-binary-v0.1.11.tgz`, updated the index, and emitted the correct download URL:
   ```text
   https://github.com/exa-labs/flyte/releases/download/flyte-binary-v0.1.11/flyte-binary-v0.1.11.tgz
   ```
4. Separately confirmed the released artifact is correct: rendered the published `flyte-binary-v0.1.11.tgz` asset and diffed it against the local chart's render — 0 lines. Only its discoverability is broken.
5. `bash -n` on the workflow's shell blocks.

The real verification is the next push to master, same as #17 and #18.

### Labels

**fixed**

## Related PRs

- #17 — fixed the dead Helm repository URLs that made this workflow fail before chart-releaser ran
- #18 — added `skip_existing` so chart-releaser stops failing on already-published charts
- #16 — the `flyte-binary` v0.1.11 HA change that needs this chart published


Link to Devin session: https://app.devin.ai/sessions/137e980b425d43668660198d80b6e21d
Requested by: @Vervious