### PR TITLE
fix(ci): create the chart index workspace before running cr index

### DIFF
--- a/.github/workflows/github-helm-charts.yaml
+++ b/.github/workflows/github-helm-charts.yaml
@@ -77,7 +77,7 @@ jobs:
           fi
 
           rm -rf .cr-index .cr-release-packages
-          mkdir -p .cr-release-packages
+          mkdir -p .cr-index .cr-release-packages
 
           while IFS=$'\t' read -r tag asset; do
             gh release download "$tag" \


### PR DESCRIPTION
## Tracking issue

Related to #19

## Why are the changes needed?

The index regeneration step added in #19 fails on master:

```text
Updating index .cr-index/index.yaml
Error: open .cr-index/index.yaml288038684: no such file or directory
```

The step does `rm -rf .cr-index .cr-release-packages` but only recreates `.cr-release-packages`. `cr index` writes its output via a temporary suffixed file next to `--index-path` and does not create that parent directory itself, so the write fails.

Everything before that point worked: `cr` v1.6.1 installed, the `origin/gh-pages` worktree was prepared, and all seven release packages were downloaded and inspected including `flyte-binary-v0.1.11.tgz`. So `flyte-binary` v0.1.11 is still missing from the published index.

## What changes were proposed in this pull request?

```diff
-          mkdir -p .cr-release-packages
+          mkdir -p .cr-index .cr-release-packages
```

## How was this patch tested?

`Release Charts` only runs on push to master, and #19's local verification passed only because it ran in a working tree that already had `.cr-index` — so this time the workflow's own shell was tested rather than an adaptation of it.

Both `run:` blocks were extracted verbatim from the committed workflow and executed in separate clean clones, with only the Actions environment stubbed (`GITHUB_REPOSITORY`, `GITHUB_REPOSITORY_OWNER`, `RUNNER_TEMP`, `GITHUB_PATH`, `CR_TOKEN`/`GH_TOKEN`, `CHART_RELEASER_VERSION`), `$GITHUB_PATH` applied between steps, and the final `--push` flag dropped so gh-pages is untouched.

At `origin/master` the harness reproduces the CI failure exactly:

```text
before_status=1
Found flyte-binary-v0.1.11.tgz
Updating index .cr-index/index.yaml
Error: open .cr-index/index.yaml288038684: no such file or directory
```

At this branch it succeeds:

```text
after_status=0
Found flyte-binary-v0.1.11.tgz
Updating index .cr-index/index.yaml
```

The clean clones had no `origin/gh-pages` ref, so the step's explicit fetch path was exercised too. Walking the rest of the step in that harness surfaced no other dependency on pre-existing local state.

### Labels

**fixed**

## Related PRs

- #19 — added the index regeneration step this fixes
- #18, #17 — the earlier `Release Charts` failures
- #16 — the `flyte-binary` v0.1.11 chart waiting on publication


Link to Devin session: https://app.devin.ai/sessions/137e980b425d43668660198d80b6e21d
Requested by: @Vervious